### PR TITLE
Allow swatches to recur

### DIFF
--- a/lib/dunmanifestin/churn.rb
+++ b/lib/dunmanifestin/churn.rb
@@ -1,0 +1,35 @@
+class Churn
+  # A churn is a data structure that stores a set of things.
+  # You can randomly pick one of those things by calling its
+  # sample() method.
+  #
+  # The wrinkle is that the set of sampleable things is not
+  # closed. The churn will sometimes, at random, generate a
+  # totally new item. You can also explicitly request a
+  # novel item by calling generate(). Any new items
+  # generated are added to the churn and may be picked on
+  # future calls to sample().
+  #
+  # Control how often the churn generates new things using
+  # the novelty: parameter to initialize().
+
+  def initialize novelty:
+    @novelty = novelty
+    @generated = 0
+    @slots = {}
+  end
+
+  def sample
+    return yield if @novelty == 0
+    r = (rand * (@novelty + @slots.length)).floor
+    @slots[r] ||= yield
+  end
+
+  def generate
+    return yield if @novelty == 0
+    @slots[@generated] ||= yield
+    value = @slots[@generated]
+    @generated += 1
+    value
+  end
+end

--- a/lib/dunmanifestin/phrase.rb
+++ b/lib/dunmanifestin/phrase.rb
@@ -74,17 +74,24 @@ class Variable
 
     self.inflections_delegated_to_me = []
     self.demanded_inflections        = []
+    self.constraints                 = []
 
     components.each_with_index do |v, k|
-      inflections_delegated_to_me << v.to_sym if components[k-1] == '#'
-      demanded_inflections << v.to_sym if components[k-1] == '.'
+      case components[k-1]
+      when '#'
+        inflections_delegated_to_me << v.to_sym
+      when '.'
+        demanded_inflections << v.to_sym
+      when ':'
+        constraints << v.to_sym
+      end
     end
   end
 
   def reify genre, inflections_of_parent_phrase
     inherited_inflections = inflections_of_parent_phrase & inflections_delegated_to_me
     inflections = demanded_inflections | inherited_inflections
-    genre.palette_named(palette_name).sample genre, inflections
+    genre.palette_named(palette_name).sample genre, inflections, constraints
   end
 
   def delegated_plural?
@@ -101,5 +108,9 @@ class Variable
 
   private
 
-  attr_accessor :demanded_inflections, :palette_name, :inflections_delegated_to_me
+  attr_accessor \
+    :demanded_inflections,
+    :palette_name,
+    :inflections_delegated_to_me,
+    :constraints
 end

--- a/spec/churn_spec.rb
+++ b/spec/churn_spec.rb
@@ -1,0 +1,47 @@
+require_relative '../lib/dunmanifestin/churn'
+
+describe Churn do
+  it 'samples from large set of items when novelty is high' do
+    c = Churn.new novelty: 10000
+    sampled = 50.times.map { c.sample { rand.*(10000).floor } }
+    expect(sampled.uniq.length).to be > 47
+  end
+
+  it 'samples from a limited set of items when novelty is low' do
+    c = Churn.new novelty: 1
+
+    sampled = 50.times.map { c.sample { rand.*(1000).floor } }
+    expect(sampled.uniq.length).to be < 20
+  end
+
+  it 'can be forced to generate a new item' do
+    c = Churn.new novelty: 1
+
+    existing = 50.times.map { c.generate { rand.*(1_000_000_000).floor } }
+    new = c.generate { rand.*(1_000_000_000).floor }
+    expect(existing).not_to include new
+  end
+
+  it 'may choose to "generate" an item that was previously coined by sample()' do
+    # This detail supports the Churn's use as a generator of
+    # recurring characters. A character specified with a
+    # phrase variable like [person:recur] should be allowed
+    # to be generated (once) by [person].
+    c = Churn.new novelty: 1
+
+    existing = 50.times.map { c.sample { rand.*(1_000_000_000).floor }}
+    new = 5.times.map { c.generate { rand.*(1_000_000_000).floor }}
+    expect(new & existing).not_to be_empty
+  end
+
+  context 'when novelty is 0' do
+    let (:c) { Churn.new novelty: 0 }
+    it 'generates' do
+      expect(c.generate { rand.*(100).floor }).to be_a Numeric
+    end
+
+    it 'samples' do
+      expect(c.sample { rand.*(100).floor }).to be_a Numeric
+    end
+  end
+end

--- a/spec/palette_spec.rb
+++ b/spec/palette_spec.rb
@@ -40,6 +40,34 @@ Ophelia
     expect(selections).to include 'Ophelia'
   end
 
+  it 'excludes the population suffix from its name' do
+    palette = Palette.new(<<-EOF, 'characters.pal')
+|person*1
+Hamlet
+    EOF
+    expect(palette.name).to eq 'person'
+  end
+
+  it 'limits the population of unique phrase renderings' do
+    syllable = Palette.new(<<-EOF, 'characters.pal')
+|syllable
+a
+thi
+ga
+i
+hi
+    EOF
+    person = Palette.new(<<-EOF, 'characters.pal')
+|person*1
+[syllable][syllable][syllable][syllable]
+    EOF
+
+    genre = Genre.new([syllable, person])
+    character = Phrase.new('[person:recur]')
+    characters = 50.times.map { character.reify genre }
+    expect(characters.uniq.length).to be < 20
+  end
+
   it 'ignores comments' do
     palette = Palette.new(<<-EOF, 'characters.pal')
 |person


### PR DESCRIPTION
This addresses https://github.com/gavmor/Dunmanifestin/issues/11.

You can specify the "starting population" of recurring characters like this:

```
|person*10
...
```

And ask for a recurring character like this:

```
[person:recur]
```

So, given input like this:

```
|root
[name] is [profession.article]
[gossip]

|gossip
[name:recur] likes [name:recur]!

|name*10
[rawName.capitalize]

...
```

Dunmanifestin generates this output, replete with love triangles:

```
$ bin/dunmanifestin -n 20
Widsar likes Catgah!
Catgah likes Gelar!
Catgah is a cobbler
Achufik likes Waukaife!
Opwuipe is a hostler
Catgah likes Wasi!
Widsar is a merchant
Suicha is a bartender
Kige is a cobbler
Achufik is a farmer
Ii likes Opwuipe!
Gelar is a mechanic
Waukaife is an innkeeper
Sainsyt is a thief
Sainsyt likes Wasi!
Gelar likes Dethuit!
Xoirax likes Waukaife!
Suicha likes Asichec!
Asichec is a thief
Aekatedw is a merchant
```

One limitation is that you can't use both `:recur` and inflections like `.capitalize`. If inflections are requested, `:recur` is ignored. Implementing the combination of `:recur` and inflections correctly would be pretty hard, and for our use case, it's not necessary.